### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/GPUberViewDemo/Pods/JSONModel/README.md
+++ b/GPUberViewDemo/Pods/JSONModel/README.md
@@ -2,7 +2,7 @@
 
 ### Version 1.1.2
 
-#####NB: Swift works in a different way under the hood than Objective-C. Therefore I can't find a way to re-create JSONModel in Swift. JSONModel in Objective-C works in Swift apps through CocoaPods or as an imported Objective-C library.
+##### NB: Swift works in a different way under the hood than Objective-C. Therefore I can't find a way to re-create JSONModel in Swift. JSONModel in Objective-C works in Swift apps through CocoaPods or as an imported Objective-C library.
 
 ---
 If you like JSONModel and use it, could you please:

--- a/GPUberViewDemo/Pods/Masonry/README.md
+++ b/GPUberViewDemo/Pods/Masonry/README.md
@@ -1,4 +1,4 @@
-#Masonry [![Build Status](https://travis-ci.org/SnapKit/Masonry.svg?branch=master)](https://travis-ci.org/SnapKit/Masonry) [![Coverage Status](https://img.shields.io/coveralls/SnapKit/Masonry.svg?style=flat-square)](https://coveralls.io/r/SnapKit/Masonry) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+# Masonry [![Build Status](https://travis-ci.org/SnapKit/Masonry.svg?branch=master)](https://travis-ci.org/SnapKit/Masonry) [![Coverage Status](https://img.shields.io/coveralls/SnapKit/Masonry.svg?style=flat-square)](https://coveralls.io/r/SnapKit/Masonry) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 **Masonry is still actively maintained, we are committed to fixing bugs and merging good quality PRs from the wider community. However if you're using Swift in your project, we recommend using [SnapKit](https://github.com/SnapKit/SnapKit) as it provides better type safety with a simpler API.**
 

--- a/GPUberViewDemo/Pods/PulsingHalo/README.md
+++ b/GPUberViewDemo/Pods/PulsingHalo/README.md
@@ -10,7 +10,7 @@ It's useful for:
 - **iBeacon**
 - annotions in MapKit
 
-##How to use
+## How to use
 
 1. Add PulsingHaloLayer.h,m into your project
 2. Initiate and add to your view.
@@ -21,9 +21,9 @@ halo.position = self.view.center;
 [self.view.layer addSublayer:halo];
 ````
 
-##Customization
+## Customization
 
-###radius
+### radius
 
 Use `radius` property.
 
@@ -31,7 +31,7 @@ Use `radius` property.
 self.halo.radius = 240.0;
 ````
 
-###color
+### color
 
 Use `backgroundColor` property.
 
@@ -44,18 +44,18 @@ UIColor *color = [UIColor colorWithRed:0.7
 self.halo.backgroundColor = color.CGColor;
 ````
 
-###animation duration
+### animation duration
 
 Use `animationDuration` or `pulseInterval` property.
 
 
-##Demo
+## Demo
 
 You can try to change radius and color properties with demo app.
 
 ![](http://f.cl.ly/items/031W0P1T190q382P063m/beacon_demo3.jpg)
 
 
-##Special Thanks
+## Special Thanks
 
 It's inspired by [SVPulsingAnnotationView](https://github.com/samvermette/SVPulsingAnnotationView).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
